### PR TITLE
Addition of wildcards and path specification to resolve #3 and #4

### DIFF
--- a/src/Storage/__tests__/Storage.spec.js
+++ b/src/Storage/__tests__/Storage.spec.js
@@ -9,13 +9,33 @@ describe('Storage', () => {
 
           get: jest.fn(() => new Promise((resolve) =>
             resolve({
-              'map=example.com': {
-                host: 'example.com',
+              'map=example.com/': {
+                host: 'example.com/',
                 container: 'example',
                 enabled: true,
               },
-              'map=kinte.sh': {
-                host: 'kinte.sh',
+              'map=kinte.sh/*': {
+                host: 'kinte.sh/*',
+                container: 'personal',
+                enabled: true,
+              },
+              'map=*.example.com/': {
+                host: '*.example.com/',
+                container: 'example',
+                enabled: true,
+              },
+              'map=*.kinte.sh/*': {
+                host: '*.kinte.sh/*',
+                container: 'personal',
+                enabled: true,
+              },
+              'map=test.example.com/here': {
+                host: 'test.example.com/here',
+                container: 'example',
+                enabled: true,
+              },
+              'map=test.kinte.sh/here': {
+                host: 'test.kinte.sh/here',
                 container: 'personal',
                 enabled: true,
               },
@@ -43,13 +63,33 @@ describe('Storage', () => {
     expect.assertions(1);
     return Storage.getAll().then((results) => {
       expect(results).toEqual({
-        'example.com': {
-          host: 'example.com',
+        'example.com/': {
+          host: 'example.com/',
           container: 'example',
           enabled: true,
         },
-        'kinte.sh': {
-          host: 'kinte.sh',
+        'kinte.sh/*': {
+          host: 'kinte.sh/*',
+          container: 'personal',
+          enabled: true,
+        },
+        '*.example.com/': {
+          host: '*.example.com/',
+          container: 'example',
+          enabled: true,
+        },
+        '*.kinte.sh/*': {
+          host: '*.kinte.sh/*',
+          container: 'personal',
+          enabled: true,
+        },
+        'test.example.com/here': {
+          host: 'test.example.com/here',
+          container: 'example',
+          enabled: true,
+        },
+        'test.kinte.sh/here': {
+          host: 'test.kinte.sh/here',
           container: 'personal',
           enabled: true,
         },
@@ -58,11 +98,60 @@ describe('Storage', () => {
   });
 
   it('should get by key', () => {
-    expect.assertions(1);
-    return Storage.get('example.com').then((result) => {
+    expect.assertions(8);
+    Storage.get('example.com/').then((result) => {
       expect(result).toEqual({
-        host: 'example.com',
+        host: 'example.com/',
         container: 'example',
+        enabled: true,
+      });
+    });
+    Storage.get('kinte.sh/').then((result) => {
+      expect(result).toEqual({
+        host: 'kinte.sh/*',
+        container: 'personal',
+        enabled: true,
+      });
+    });
+    Storage.get('test.example.com/').then((result) => {
+      expect(result).toEqual({
+        host: '*.example.com/',
+        container: 'example',
+        enabled: true,
+      });
+    });
+    Storage.get('test.kinte.sh/').then((result) => {
+      expect(result).toEqual({
+        host: '*.kinte.sh/*',
+        container: 'personal',
+        enabled: true,
+      });
+    });
+    Storage.get('test.example.com/test').then((result) => {
+      expect(result).toEqual({
+        host: '*.example.com/',
+        container: 'example',
+        enabled: true,
+      });
+    });
+    Storage.get('test.kinte.sh/test').then((result) => {
+      expect(result).toEqual({
+        host: '*.kinte.sh/*',
+        container: 'personal',
+        enabled: true,
+      });
+    });
+    Storage.get('test.example.com/here').then((result) => {
+      expect(result).toEqual({
+        host: 'test.example.com/here',
+        container: 'example',
+        enabled: true,
+      });
+    });
+    return Storage.get('test.kinte.sh/here/there').then((result) => {
+      expect(result).toEqual({
+        host: 'test.kinte.sh/here',
+        container: 'personal',
         enabled: true,
       });
     });
@@ -70,13 +159,13 @@ describe('Storage', () => {
 
   it('should set all', () => {
     const hostMaps = {
-      'example.com': {
-        host: 'example.com',
+      'example.com/': {
+        host: 'example.com/',
         container: 'example',
         enabled: true,
       },
-      'kinte.sh': {
-        host: 'kinte.sh',
+      'kinte.sh/': {
+        host: 'kinte.sh/',
         container: 'personal',
         enabled: true,
       },
@@ -85,13 +174,13 @@ describe('Storage', () => {
     expect.assertions(1);
     return Storage.setAll(hostMaps).then(({key}) => {
       expect(key).toEqual({
-        'map=example.com': {
-          host: 'example.com',
+        'map=example.com/': {
+          host: 'example.com/',
           container: 'example',
           enabled: true,
         },
-        'map=kinte.sh': {
-          host: 'kinte.sh',
+        'map=kinte.sh/': {
+          host: 'kinte.sh/',
           container: 'personal',
           enabled: true,
         },
@@ -101,16 +190,16 @@ describe('Storage', () => {
 
   it('should set one entry', () => {
     const hostMap = {
-      host: 'example.com',
+      host: 'example.com/',
       container: 'example',
       enabled: true,
     };
 
     expect.assertions(2);
     return Storage.set(hostMap).then(({key, value}) => {
-      expect(key).toEqual('map=example.com');
+      expect(key).toEqual('map=example.com/');
       expect(value).toEqual({
-        host: 'example.com',
+        host: 'example.com/',
         container: 'example',
         enabled: true,
       });
@@ -119,8 +208,8 @@ describe('Storage', () => {
 
   it('should remove one entry', () => {
     expect.assertions(1);
-    return Storage.remove('example.com').then(({key}) => {
-      expect(key).toEqual('map=example.com');
+    return Storage.remove('example.com/').then(({key}) => {
+      expect(key).toEqual('map=example.com/');
     });
   });
 

--- a/src/Storage/__tests__/Storage.spec.js
+++ b/src/Storage/__tests__/Storage.spec.js
@@ -39,6 +39,11 @@ describe('Storage', () => {
                 container: 'personal',
                 enabled: true,
               },
+              'map=this.com': {  // Old-style map, no '/' at the end.
+                host: 'this.com',  // Will convert to new style any get() call
+                container: 'work',
+                enabled: true,
+              },
             }),
           )),
 
@@ -93,16 +98,28 @@ describe('Storage', () => {
           container: 'personal',
           enabled: true,
         },
+        'this.com': {
+          host: 'this.com',
+          container: 'work',
+          enabled: true,
+        },
       });
     });
   });
 
   it('should get by key', () => {
-    expect.assertions(8);
+    expect.assertions(9);
     Storage.get('example.com/').then((result) => {
       expect(result).toEqual({
         host: 'example.com/',
         container: 'example',
+        enabled: true,
+      });
+    });
+    Storage.get('this.com/').then((result) => {  // Old maps convert?
+      expect(result).toEqual({
+        host: 'this.com/',
+        container: 'work',
         enabled: true,
       });
     });

--- a/src/Storage/index.js
+++ b/src/Storage/index.js
@@ -1,3 +1,5 @@
+import {domainMatch, pathMatch, sortMaps} from '../utils';
+
 class Storage {
 
   constructor() {
@@ -18,8 +20,18 @@ class Storage {
   }
 
   get(key) {
-    return this.storage.get(`${this.mapPrefix}${key}`).then((result) => result[`${this.mapPrefix}${key}`]);
-  }
+    return this.getAll().then(maps => {
+      const sorted = sortMaps(Object.keys(maps).map(key => maps[key]));
+      // Sorts by domain length, then by path length
+      for (var i = 0; i < sorted.length; ++i) {
+        const map = sorted[i];
+        if (domainMatch(key, map))
+          if (pathMatch(key, map))
+            return map;
+      }
+      return {};
+    });
+ }
 
   setAll(obj = {}) {
     const prefixedObj = {};

--- a/src/ui/URLMaps.js
+++ b/src/ui/URLMaps.js
@@ -69,6 +69,8 @@ class URLMaps {
       const host = cleanHostInput(urlInput && urlInput.value);
 
       if (host) {
+        const map_host = (host.slice(-1) == '*' || host.slice(-1) == '/') ? host : host + '/';
+        // append a '/' to the end of the rule, this makes sure there is a path
         maps[host] = {
           host,
           containerName: this.state.selectedIdentity.name,

--- a/src/ui/URLMaps.js
+++ b/src/ui/URLMaps.js
@@ -69,10 +69,10 @@ class URLMaps {
       const host = cleanHostInput(urlInput && urlInput.value);
 
       if (host) {
-        const map_host = (host.slice(-1) == '*' || host.slice(-1) == '/') ? host : host + '/';
+        const map_host = (host.indexOf('/') == -1) ? host + '/' : host;
         // append a '/' to the end of the rule, this makes sure there is a path
-        maps[host] = {
-          host,
+        maps[map_host] = {
+          host: map_host,
           containerName: this.state.selectedIdentity.name,
           cookieStoreId: this.state.selectedIdentity.cookieStoreId,
           enabled: true,

--- a/src/utils.js
+++ b/src/utils.js
@@ -11,6 +11,9 @@ const domainLength = (map) => getDomain(map).replace('*.', '').split('.').length
 const pathLength = (map) => getPath(map).replace('/*', '').split('/').length;
 
 export const sortMaps = (maps) => maps.sort((map1, map2) => {
+  // Fix for old style rules with no path
+  if (map1.host.indexOf('/') == -1) map1.host = map1.host.concat('/');
+  if (map2.host.indexOf('/') == -1) map2.host = map2.host.concat('/');
   const d1 = domainLength(map1.host);
   const d2 = domainLength(map2.host);
   const p1 = pathLength(map1.host);

--- a/src/utils.js
+++ b/src/utils.js
@@ -22,7 +22,6 @@ export const sortMaps = (maps) => maps.sort((map1, map2) => {
 export const domainMatch = (url, map) => {
   const url_host = getDomain(url);
   const map_host = getDomain(map.host);
-  if (map.host == "test.kinte.sh/here/") {console.log(url_host); console.log(map_host);}
   if (map_host.slice(0,2) != '*.') return url_host == map_host;
   // Check wildcard matches in reverse order (com.example.*)
   const wild_url = url_host.split('.').reverse();

--- a/src/utils.js
+++ b/src/utils.js
@@ -22,6 +22,7 @@ export const sortMaps = (maps) => maps.sort((map1, map2) => {
 export const domainMatch = (url, map) => {
   const url_host = getDomain(url);
   const map_host = getDomain(map.host);
+  if (map.host == "test.kinte.sh/here/") {console.log(url_host); console.log(map_host);}
   if (map_host.slice(0,2) != '*.') return url_host == map_host;
   // Check wildcard matches in reverse order (com.example.*)
   const wild_url = url_host.split('.').reverse();
@@ -37,10 +38,9 @@ export const pathMatch = (url, map) => {
   const url_path = getPath(url);
   const map_path = getPath(map.host);
   if (map_path == '*' || map_path == '') return true;
-  if (map_path.slice(-2) != '/*') return url_path == map_path;
-
+  // Paths are always wild
   const wild_url = url_path.split('/');
-  const wild_map = map_path.slice(0,-2).split('/');
+  const wild_map = map_path.replace('/*', '').split('/');
   if (wild_url.length < wild_map.length) return false;
 
   for (var i = 0; i < wild_map.length ; ++i)

--- a/src/utils.js
+++ b/src/utils.js
@@ -11,18 +11,18 @@ const domainLength = (map) => getDomain(map).replace('*.', '').split('.').length
 const pathLength = (map) => getPath(map).replace('/*', '').split('/').length;
 
 export const sortMaps = (maps) => maps.sort((map1, map2) => {
-  const d1 = domainLength(map1);
-  const d2 = domainLength(map2);
-  const p1 = pathLength(map1);
-  const p2 = pathLength(map2);
+  const d1 = domainLength(map1.host);
+  const d2 = domainLength(map2.host);
+  const p1 = pathLength(map1.host);
+  const p2 = pathLength(map2.host);
   if (d1==d2 && p1==p2) return 0;
   return ((d1==d2) ? (p1<p2) : (d1<d2)) ? 1 : -1;
 });
 
 export const domainMatch = (url, map) => {
   const url_host = getDomain(url);
-  const map_host = getDomain(map);
-  if (map.slice(0,2) != '*.') return url_host == map_host;
+  const map_host = getDomain(map.host);
+  if (map_host.slice(0,2) != '*.') return url_host == map_host;
   // Check wildcard matches in reverse order (com.example.*)
   const wild_url = url_host.split('.').reverse();
   const wild_map = map_host.slice(2).split('.').reverse();
@@ -35,8 +35,9 @@ export const domainMatch = (url, map) => {
 
 export const pathMatch = (url, map) => {
   const url_path = getPath(url);
-  const map_path = getPath(map);
-  if (map.slice(-2) != '/*') return url_path == map_path;
+  const map_path = getPath(map.host);
+  if (map_path == '*' || map_path == '') return true;
+  if (map_path.slice(-2) != '/*') return url_path == map_path;
 
   const wild_url = url_path.split('/');
   const wild_map = map_path.slice(0,-2).split('/');

--- a/src/utils.js
+++ b/src/utils.js
@@ -3,3 +3,46 @@ export const qsAll = (selector, node) => (node || document).querySelectorAll(sel
 export const ce = (tagName) => document.createElement(tagName);
 
 export const cleanHostInput = (value = '') => value.trim().toLowerCase();
+
+const getDomain = (src = '') => src.split('/')[0];
+const getPath = (src = '') => src.replace(/^.+?\//, '');
+
+const domainLength = (map) => getDomain(map).replace('*.', '').split('.').length;
+const pathLength = (map) => getPath(map).replace('/*', '').split('/').length;
+
+export const sortMaps = (maps) => maps.sort((map1, map2) => {
+  const d1 = domainLength(map1);
+  const d2 = domainLength(map2);
+  const p1 = pathLength(map1);
+  const p2 = pathLength(map2);
+  if (d1==d2 && p1==p2) return 0;
+  return ((d1==d2) ? (p1<p2) : (d1<d2)) ? 1 : -1;
+});
+
+export const domainMatch = (url, map) => {
+  const url_host = getDomain(url);
+  const map_host = getDomain(map);
+  if (map.slice(0,2) != '*.') return url_host == map_host;
+  // Check wildcard matches in reverse order (com.example.*)
+  const wild_url = url_host.split('.').reverse();
+  const wild_map = map_host.slice(2).split('.').reverse();
+  if (wild_url.length < wild_map.length) return false;
+
+  for (var i = 0; i < wild_map.length ; ++i)
+    if (wild_url[i] != wild_map[i]) return false;
+  return true;
+};
+
+export const pathMatch = (url, map) => {
+  const url_path = getPath(url);
+  const map_path = getPath(map);
+  if (map.slice(-2) != '/*') return url_path == map_path;
+
+  const wild_url = url_path.split('/');
+  const wild_map = map_path.slice(0,-2).split('/');
+  if (wild_url.length < wild_map.length) return false;
+
+  for (var i = 0; i < wild_map.length ; ++i)
+    if (wild_url[i] != wild_map[i]) return false;
+  return true;
+};

--- a/src/webRequestListener.js
+++ b/src/webRequestListener.js
@@ -23,7 +23,7 @@ export const webRequestListener = (requestDetails) => {
   }
 
   const url = new window.URL(requestDetails.url);
-  const hostname = url.hostname.replace('www.', '');
+  const hostname = url.hostname.replace('www.', '') + url.pathname;
 
   return Promise.all([
     Storage.get(hostname),


### PR DESCRIPTION
Let me begin by thanking you for bringing this downright necessary extension into existence. This PR contains an implementation of the most requested feature: wildcard support. The attempt was to stay as close to the original source as reasonable. A summary of the changes:

* **A path is required.** A simple '/' at the end of the hostname is all that is necessary. If not specified in the input, it is appended.
* **A wildcard leads to a matching of all present qualifiers.** For instance, `*.example.com` will check for `example.com`, and if this matches then the rule matches (`example.com`, `here.example.com`, and `here.there.example.com` will all match).
* **A wildcard is implied in the path.** This is simply because the path is to a folder and not a specific file, and so any file in the shoulder should match the rule (the map). Thus, any wildcards in the path are stripped: `example.com/*` is equivalent to `example.com/`.
* **All maps are sorted before attempting to match to a URI.** This sort is from most the least complex, which makes sure that a rule for `here.example.com/` is matched before `*.example.com/`. The complexity is determined by the number of domains, then the number of paths.
* **More tests were added** to check for this functionality. While not exhaustively tested, I've used it for half a week, with this final version having no real issues.
*As for **backwards compatibility**, the only change is the inclusion of a slash at the end of rules with no paths. This last commit includes a fix for maps already in storage: when a URI is checked, all old maps are updated.

I encourage you to review this PR, and hope it serves at the very least as inspiration on how to implement this feature.