### PR TITLE
Match domain & path against lowered case values

### DIFF
--- a/src/Storage/index.js
+++ b/src/Storage/index.js
@@ -23,8 +23,8 @@ class Storage {
       const sorted = sortMaps(Object.keys(maps).map(key => maps[key]));
       // Sorts by domain length, then by path length
       for (const map of sorted) {
-        const url = (key.indexOf('/') === -1) ? key.concat('/') : key;
-        const mapHost = (map.host.indexOf('/') === -1) ? map.host.concat('/') : map.host;
+        const url = ((key.indexOf('/') === -1) ? key.concat('/') : key).toLowerCase();
+        const mapHost = ((map.host.indexOf('/') === -1) ? map.host.concat('/') : map.host).toLowerCase();
         if (domainMatch(url, mapHost) && pathMatch(url, mapHost)) {
           return map;
         }


### PR DESCRIPTION
This is a kind of naive approach to #4 issue of case sensitivity for domain/path matching.

Keeping the string case while storing the domain/path list would be cleaner/better imho, but it can also cause some issues with matching URLs like `https://github.com/kintesh` and `https://github.com/Kintesh` that are resolved to the same web page.