### PR TITLE
Fix updating entries that don't remove the old entry

### DIFF
--- a/src/ui/URLMaps.js
+++ b/src/ui/URLMaps.js
@@ -80,6 +80,7 @@ class URLMaps {
     }
 
     Promise.all([
+      Storage.clear(),
       Storage.setAll(maps),
     ]).then(() => {
       hideLoader();


### PR DESCRIPTION
Since there's upper level in the storage entries and they are all flat,
 the storage is cleared completely. This could be changed in the future
 in order to add a level e.g "entries" in order to allow other keys like
 "state" or "preferences".

kintesh/containerise#45 Updating entries leaves the old entry and creates a new one