### PR TITLE
Support internationalized domain names with punycode

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "file-loader": "1.1.11",
     "jest": "22.4.4",
     "node-sass": "4.9.0",
+    "punycode": "^2.1.1",
     "sass-loader": "7.0.1",
     "style-loader": "0.21.0",
     "web-ext": "2.6.0",

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,5 @@
+import punycode from 'punycode';
+
 export const qs = (selector, node) => (node || document).querySelector(selector);
 export const qsAll = (selector, node) => (node || document).querySelectorAll(selector);
 export const ce = (tagName) => document.createElement(tagName);
@@ -49,5 +51,5 @@ export const pathMatch = (url, map) => {
 
 export const urlKeyFromUrl = (url) => {
   const parsedUrl = new window.URL(url);
-  return parsedUrl.hostname.replace('www.', '') + parsedUrl.pathname;
+  return punycode.toUnicode(parsedUrl.hostname.replace('www.', '')) + parsedUrl.pathname;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -6004,6 +6004,11 @@ punycode@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.0.tgz#5f863edc89b96db09074bad7947bf09056ca4e7d"
 
+punycode@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
+  integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+
 q@^1.1.2:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"


### PR DESCRIPTION
The URLs received from firefox are encoded, so we decode them first
 before checking if they match the user-defined patterns.
This means that encoded used-defined patterns will NOT match

kintesh/containerise#9 Support internationalized domain names