### PR TITLE
Add basic glob support

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -73,6 +73,11 @@ export const matchesSavedMap = (url, map) => {
     const savedHost = map.host;
     if (savedHost[0] === PREFIX_REGEX) {
         return new RegExp(savedHost.substr(1)).test(url);
+    } else if (savedHost[0] === PREFIX_GLOB) {
+        // turning glob into regex isn't the worst thing:
+        // 1. * becomes .*
+        // 2. ? becomes .?
+        return new RegExp(savedHost.substr(1).replace(/\*/g, '.*').replace(/\?/g, '.?')).test(url);
     } else {
         const key = urlKeyFromUrl(url);
         const _url = ((key.indexOf('/') === -1) ? key.concat('/') : key).toLowerCase();


### PR DESCRIPTION
This PR finishes the great work started by @LoveIsGrief by adding glob support. Accomplishing this is very simple: since glob is so similar to regex, we simply make some minor adjustments to the glob'd rule to make it into a regex and then test our urls as such.

Closes #51 and #21