### PR TITLE
CSVEditor: Fix delimiter bug (closes #57)

### DIFF
--- a/src/ui/CSVEditor.js
+++ b/src/ui/CSVEditor.js
@@ -76,8 +76,8 @@ class CSVEditor {
 
     Promise.all(items.map((item) => {
       const hostMapParts = item.split(HOST_MAPS_SPLIT_KEY);
-      const host = cleanHostInput(hostMapParts[0]);
-      const containerName = hostMapParts[1];
+      const host = cleanHostInput(hostMapParts.slice(0, -1).join(HOST_MAPS_SPLIT_KEY));
+      const containerName = hostMapParts[hostMapParts.length - 1];
       let identity;
 
       if (host && containerName) {


### PR DESCRIPTION
This bug had a really simple cause: the code to split host and container
assumed that there would be only one delimiter. Now that regex is in
play, it's likely that whatever the delimiter is decided upon, it will
be found in some host string.

The fix is to assume that the container name _doesn't_ have
the delimiter in it, and therefore the last element in the
delimiter-split array is the container and everything before is the
host.

I haven't tested this in the app but in the console it works.