### PR TITLE
Open any url not assigned to a container in the default container

### DIFF
--- a/src/ui/URLMaps.js
+++ b/src/ui/URLMaps.js
@@ -46,8 +46,8 @@ class URLMaps {
     }
 
     let isDefaultContainer = this.state.selectedIdentity.cookieStoreId === NO_CONTAINER.cookieStoreId;
-    addButton.style.display = isDefaultContainer ? "none" : "initial";
-    saveButton.style.display = isDefaultContainer ? "none" : "initial";
+    addButton.style.display = isDefaultContainer ? 'none' : 'initial';
+    saveButton.style.display = isDefaultContainer ? 'none' : 'initial';
 
     hideLoader();
   }

--- a/src/ui/URLMaps.js
+++ b/src/ui/URLMaps.js
@@ -1,5 +1,6 @@
 import State from '../State';
 import Storage from '../Storage';
+import {NO_CONTAINER} from '../ContextualIdentity';
 import {qs, qsAll} from '../utils';
 import {showLoader, hideLoader} from './loader';
 import {showToast, hideToast} from './toast';
@@ -37,10 +38,16 @@ class URLMaps {
 
     for (const key in this.state.urlMaps) {
       const urlMap = this.state.urlMaps[key];
-      if (this.state.selectedIdentity.cookieStoreId === urlMap.cookieStoreId) {
-        this.addItem(urlMap.host);
+      if (urlMap.cookieStoreId !== NO_CONTAINER.cookieStoreId) {
+        if (this.state.selectedIdentity.cookieStoreId === urlMap.cookieStoreId) {
+          this.addItem(urlMap.host);
+        }
       }
     }
+
+    let isDefaultContainer = this.state.selectedIdentity.cookieStoreId === NO_CONTAINER.cookieStoreId;
+    addButton.style.display = isDefaultContainer ? "none" : "initial";
+    saveButton.style.display = isDefaultContainer ? "none" : "initial";
 
     hideLoader();
   }

--- a/src/webRequestListener.js
+++ b/src/webRequestListener.js
@@ -39,6 +39,11 @@ export const webRequestListener = (requestDetails) => {
     const hostIdentity = identities.find((identity) => identity.cookieStoreId === hostMap.cookieStoreId);
     const tabIdentity = identities.find((identity) => identity.cookieStoreId === currentTab.cookieStoreId);
 
+    if (!hostIdentity && currentTab.cookieStoreId !== NO_CONTAINER.cookieStoreId && tabIdentity) {
+      return createTab(requestDetails.url, currentTab.index + 1, currentTab.id);
+    }
+
+
     if (!hostIdentity) {
       return {};
     }


### PR DESCRIPTION
This change only keeps urls explicitly assigned to a container into that container. Urls not assigned to a container will be opened into the default one (ie. 'No Container'). As such, assigning urls to 'No Container' no longer makes sense and has been removed.