### PR TITLE
Make sure to execute promises in order in CSVEditor::saveUrlMaps

### DIFF
--- a/src/ui/CSVEditor.js
+++ b/src/ui/CSVEditor.js
@@ -74,7 +74,7 @@ class CSVEditor {
     const maps = {};
     const missingContainers = new Map();
 
-    Promise.all(items.map((item) => {
+    await Promise.all(items.map((item) => {
       const hostMapParts = item.split(HOST_MAPS_SPLIT_KEY);
       const host = cleanHostInput(hostMapParts.slice(0, -1).join(HOST_MAPS_SPLIT_KEY));
       const containerName = hostMapParts[hostMapParts.length - 1];
@@ -97,14 +97,12 @@ class CSVEditor {
 
     await this.createMissingContainers(missingContainers, maps);
 
-    Promise.all([
-      Storage.clear(),
-      Storage.setAll(maps),
-    ]).then(() => {
-      hideLoader();
-      showToast('Saved!');
-      setTimeout(() => hideToast(), 3000);
-    });
+    await Storage.clear();
+    await Storage.setAll(maps);
+
+    hideLoader();
+    showToast('Saved!');
+    setTimeout(() => hideToast(), 3000);
   }
 
   showEditor() {


### PR DESCRIPTION
For some reason the `Storage.clear` would come right after the `Storage.setAll`
 when the text field wasn't changed. Order of these promises
 is however imperative and shouldn't be left to chance.

Related to #84 - CSV editor wipes all entries when saved input is unmodified