### PR TITLE
Additionally listen to tab updates to catch events that slip by webrequests

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import './manifest.json';
-import {webRequestListener} from './webRequestListener';
+import {tabUpdatedListener, webRequestListener} from './containers';
 import {messageExternalListener} from './messageExternalListener';
 
 browser.webRequest.onBeforeRequest.addListener(
@@ -10,4 +10,8 @@ browser.webRequest.onBeforeRequest.addListener(
 
 browser.runtime.onMessageExternal.addListener(
   messageExternalListener
+);
+
+browser.tabs.onUpdated.addListener(
+    tabUpdatedListener
 );


### PR DESCRIPTION


For some reason some keyword searches like https://www.gamekult.com/rechercher-jeu.html?q=%s actually aren't caught.
They pass through a javascript file e.g https://www.gamekult.com/sw.js instead which does the XHR request and presents the results.
For whatever reason firefox doesn't catch that in the webrequest listeners (possibly a bug?), so we're forced to look at the changing URL of the tab and react to that.

Related to #43 - Catch keyword-based searches