### PR TITLE
Pass openerTabId to created tabs

### DIFF
--- a/src/containers.js
+++ b/src/containers.js
@@ -47,11 +47,11 @@ function handle(url, tabId) {
 
     const openerTabId = currentTab.openerTabId;
     if (hostIdentity.cookieStoreId === NO_CONTAINER.cookieStoreId && tabIdentity) {
-      return createTab(requestDetails.url, currentTab.index + 1, currentTab.id, undefined , openerTabId);
+      return createTab(url, currentTab.index + 1, currentTab.id, undefined , openerTabId);
     }
 
     if (hostIdentity.cookieStoreId !== currentTab.cookieStoreId && hostIdentity.cookieStoreId !== NO_CONTAINER.cookieStoreId) {
-      return createTab(requestDetails.url, currentTab.index + 1, currentTab.id, hostIdentity.cookieStoreId, openerTabId);
+      return createTab(url, currentTab.index + 1, currentTab.id, hostIdentity.cookieStoreId, openerTabId);
     }
 
     return {};

--- a/src/webRequestListener.js
+++ b/src/webRequestListener.js
@@ -2,7 +2,7 @@ import Storage from './Storage/HostStorage';
 import ContextualIdentity, {NO_CONTAINER} from './ContextualIdentity';
 import Tabs from './Tabs';
 
-const createTab = (url, newTabIndex, currentTabId, cookieStoreId) => {
+const createTab = (url, newTabIndex, currentTabId, cookieStoreId, openerTabId) => {
 
   Tabs.get(currentTabId).then((currentTab) => {
     Tabs.create({
@@ -10,6 +10,7 @@ const createTab = (url, newTabIndex, currentTabId, cookieStoreId) => {
       index: newTabIndex,
       cookieStoreId,
       active: currentTab.active,
+      openerTabId: openerTabId,
     });
 
     Tabs.remove(currentTabId);
@@ -43,12 +44,13 @@ export const webRequestListener = (requestDetails) => {
       return {};
     }
 
+    const openerTabId = currentTab.openerTabId;
     if (hostIdentity.cookieStoreId === NO_CONTAINER.cookieStoreId && tabIdentity) {
-      return createTab(requestDetails.url, currentTab.index + 1, currentTab.id);
+      return createTab(requestDetails.url, currentTab.index + 1, currentTab.id, undefined , openerTabId);
     }
 
     if (hostIdentity.cookieStoreId !== currentTab.cookieStoreId && hostIdentity.cookieStoreId !== NO_CONTAINER.cookieStoreId) {
-      return createTab(requestDetails.url, currentTab.index + 1, currentTab.id, hostIdentity.cookieStoreId);
+      return createTab(requestDetails.url, currentTab.index + 1, currentTab.id, hostIdentity.cookieStoreId, openerTabId);
     }
 
     return {};


### PR DESCRIPTION
Tabs that replace old one should keep the `openerTabId` of the replaced tab for use in other extensions like [Tree Style Tab](https://addons.mozilla.org/nl/firefox/addon/tree-style-tab)

