### PR TITLE
Fix #89 endless loop between container and no container since 3.4.0 

### DIFF
--- a/src/Tabs/index.js
+++ b/src/Tabs/index.js
@@ -12,6 +12,10 @@ class Tabs {
     return this.tabs.create(options);
   }
 
+  update(tabId, options = {}) {
+    return this.tabs.update(tabId, options);
+  }
+
   remove(tabId) {
     return this.tabs.remove(tabId);
   }

--- a/src/containers.js
+++ b/src/containers.js
@@ -3,7 +3,7 @@ import ContextualIdentity, {NO_CONTAINER} from './ContextualIdentity';
 import Tabs from './Tabs';
 import PreferenceStorage from './Storage/PreferenceStorage';
 
-const createTab = (url, newTabIndex, currentTabId, cookieStoreId, openerTabId) => {
+const createTab = (url, newTabIndex, currentTabId, openerTabId, cookieStoreId) => {
   Tabs.get(currentTabId).then((currentTab) => {
     const createOptions = {
       url,
@@ -58,11 +58,11 @@ function handle(url, tabId) {
 
     const openerTabId = currentTab.openerTabId;
     if (hostIdentity.cookieStoreId === NO_CONTAINER.cookieStoreId && tabIdentity) {
-      return createTab(url, currentTab.index + 1, currentTab.id, undefined , openerTabId);
+      return createTab(url, currentTab.index + 1, currentTab.id, openerTabId);
     }
 
     if (hostIdentity.cookieStoreId !== currentTab.cookieStoreId && hostIdentity.cookieStoreId !== NO_CONTAINER.cookieStoreId) {
-      return createTab(url, currentTab.index + 1, currentTab.id, hostIdentity.cookieStoreId, openerTabId);
+      return createTab(url, currentTab.index + 1, currentTab.id, openerTabId, hostIdentity.cookieStoreId);
     }
 
     return {};

--- a/src/containers.js
+++ b/src/containers.js
@@ -5,15 +5,26 @@ import PreferenceStorage from './Storage/PreferenceStorage';
 
 const createTab = (url, newTabIndex, currentTabId, cookieStoreId, openerTabId) => {
   Tabs.get(currentTabId).then((currentTab) => {
-    Tabs.create({
+    const createOptions = {
       url,
       index: newTabIndex,
       cookieStoreId,
       active: currentTab.active,
-      openerTabId: openerTabId,
+    };
+    // Passing the openerTabId without a cookieStoreId
+    // creates a tab in the same container as the opener
+    if (cookieStoreId && openerTabId) {
+      createOptions.openerTabId = openerTabId;
+    }
+    Tabs.create(createOptions).then((createdTab) => {
+      if (!cookieStoreId && openerTabId) {
+        Tabs.update(createdTab.id, {
+          openerTabId: openerTabId,
+        });
+      }
     });
     PreferenceStorage.get('keepOldTabs').then(({value}) => {
-      if(!value){
+      if (!value) {
         Tabs.remove(currentTabId);
       }
     }).catch(() => {
@@ -63,7 +74,6 @@ export const webRequestListener = (requestDetails) => {
   if (requestDetails.frameId !== 0 || requestDetails.tabId === -1) {
     return {};
   }
-
   return handle(requestDetails.url, requestDetails.tabId);
 };
 
@@ -71,5 +81,6 @@ export const tabUpdatedListener = (tabId, changeInfo) => {
   if (!changeInfo.url) {
     return;
   }
+  console.log(tabId, 'url changed', changeInfo.url);
   return handle(changeInfo.url, tabId);
 };


### PR DESCRIPTION
Passes openerTabId only for new tabs in a container

Passing the openerTabId without a cookieStoreId creates a tab in the same container as the opener. This isn't what we want when the tab is supposed to be opened without a container.
We would try to create a new tab without a container, fail and retry ad infinitum.

In this case we simply attempt to update the tab with the openerId after creation without passing it at creation time

Closes #89 