### PR TITLE
Fix non-existent icon in devmode

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import './manifest.json';
+import '../static/icons/icon.png';
 import {tabUpdatedListener, webRequestListener} from './containers';
 import {messageExternalListener} from './messageExternalListener';
 

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -39,6 +39,18 @@ module.exports = {
         ],
       },
       {
+        test: /icons\/.*$/,
+        type: 'javascript/auto',
+        use: [
+          {
+            loader: 'file-loader',
+            options: {
+              name: 'icons/[name].[ext]',
+            },
+          },
+        ],
+      },
+      {
         test: /\.(html)$/,
         type: 'javascript/auto',
         use: [


### PR DESCRIPTION
The icon isn't copied over to the build directory during development.
This takes care of that

**Result**:
![afbeelding](https://user-images.githubusercontent.com/2829538/64692597-da591e80-d495-11e9-8fc3-368720d5d73b.png)

Dunno if `npm run postbuild` is still necessary after this.