### PR TITLE
Ignore URLs not supported by tabs.create

### DIFF
--- a/src/containers.js
+++ b/src/containers.js
@@ -5,7 +5,7 @@ import PreferenceStorage from './Storage/PreferenceStorage';
 import {filterByKey} from './utils';
 import {buildDefaultContainer} from './defaultContainer';
 
-const IGNORED_URLS_REGEX = /^(about|moz-extension):/;
+const IGNORED_URLS_REGEX = /^(about|moz-extension|file|javascript|data|chrome):/;
 
 /**
  * Keep track of the tabs we're creating


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/create

> Passing any of the following URLs will fail:
>
> - chrome: URLs
> - javascript: URLs
> - data: URLs
> - file: URLs (i.e., files on the filesystem. However, to use a file packaged inside the extension, see below)
    privileged about: URLs (for example, about:config, about:addons, about:debugging).
    Non-privileged URLs (e.g., about:blank) are allowed.
> - The New Tab page (about:newtab) can be opened if no value for URL is provided.

Closes #103 