### PR TITLE
Unify container switching conditions

### DIFF
--- a/src/containers.js
+++ b/src/containers.js
@@ -79,7 +79,7 @@ async function handle(url, tabId) {
           url
       );
       targetCookieStoreId = defaultContainer.cookieStoreId;
-      console.debug('Going to open', url, 'in default container', targetCookieStoreId, defaultContainer.name);
+      // console.debug('Going to open', url, 'in default container', targetCookieStoreId, defaultContainer.name);
     } else {
       return {};
     }


### PR DESCRIPTION
The conditions when opening in the default firefox container (NO_CONTAINER in our code) were different to when opening in any other container. We didn't check if the container was changing, so NO_CONTAINER targets would keep closing the old tab and creating a new one despite no actual container change happening.

That was because it was assumed passing a container ID when creating a tab would always open the tab a container. In fact the default container does have an ID, thus we can always pass a container ID to `tabs.create`.

We now do all the same checks before opening a tab in a new container (including if the container is being switched).

Fixes #102 - Browsing sites bound to No Container open up in new tabs