### PR TITLE
Add preference to match using hostname only

### DIFF
--- a/src/Storage/HostStorage.js
+++ b/src/Storage/HostStorage.js
@@ -8,11 +8,11 @@ class HostStorage extends PrefixStorage {
     this.SET_KEY = 'host';
   }
 
-  get(url) {
+  get(url, matchDomainOnly) {
     return super.getAll().then(maps => {
       const sorted = sortMaps(Object.keys(maps).map(key => maps[key]));
       // Sorts by domain length, then by path length
-      return sorted.find(matchesSavedMap.bind(null, url)) || {};
+      return sorted.find(matchesSavedMap.bind(null, url, matchDomainOnly)) || {};
     });
   }
 

--- a/src/containers.js
+++ b/src/containers.js
@@ -57,10 +57,9 @@ async function handle(url, tabId) {
   } else if (creatingUrl) {
     delete creatingTabs[tabId];
   }
-
-  let [hostMap, preferences, identities, currentTab] = await Promise.all([
-    Storage.get(url),
-    PreferenceStorage.getAll(true),
+  let preferences = await PreferenceStorage.getAll(true);
+  let [hostMap, identities, currentTab] = await Promise.all([
+    Storage.get(url, preferences.matchDomainOnly),
     ContextualIdentity.getAll(),
     Tabs.get(tabId),
   ]);

--- a/src/ui-preferences/preferences.json
+++ b/src/ui-preferences/preferences.json
@@ -1,6 +1,12 @@
 [
   {
     "type": "bool",
+    "name": "matchDomainOnly",
+    "label": "Match domain only",
+    "description": "When matching rules to a URL, only use the domain as criteria"
+  },
+  {
+    "type": "bool",
     "name": "keepOldTabs",
     "label": "Keep old tabs",
     "description": "After a contained tab has been created, the old won't be closed"

--- a/src/utils.js
+++ b/src/utils.js
@@ -65,16 +65,22 @@ export const urlKeyFromUrl = (url) => {
  *  - glob
  *  - standard
  *
- * @param url {URL}
+ * @param url {String}
+ * @param matchDomainOnly {Boolean=}
  * @param map
  * @return {*}
  */
-export const matchesSavedMap = (url, map) => {
+export const matchesSavedMap = (url, matchDomainOnly, map) => {
   const savedHost = map.host;
+  let toMatch = url;
+  if (matchDomainOnly) {
+    toMatch = new window.URL(url).host;
+  }
+
   if (savedHost[0] === PREFIX_REGEX) {
     const regex = savedHost.substr(1);
     try {
-      return new RegExp(regex).test(url);
+      return new RegExp(regex).test(toMatch);
     } catch (e) {
       console.error('couldn\'t test regex', regex, e);
     }
@@ -82,9 +88,12 @@ export const matchesSavedMap = (url, map) => {
     // turning glob into regex isn't the worst thing:
     // 1. * becomes .*
     // 2. ? becomes .?
-    return new RegExp(savedHost.substr(1).replace(/\*/g, '.*').replace(/\?/g, '.?')).test(url);
+    return new RegExp(savedHost.substr(1)
+        .replace(/\*/g, '.*')
+        .replace(/\?/g, '.?'))
+        .test(toMatch);
   } else {
-    const key = urlKeyFromUrl(url);
+    const key = urlKeyFromUrl(toMatch);
     const _url = ((key.indexOf('/') === -1) ? key.concat('/') : key).toLowerCase();
     const mapHost = ((map.host.indexOf('/') === -1) ? map.host.concat('/') : map.host).toLowerCase();
     return domainMatch(_url, mapHost) && pathMatch(_url, mapHost);


### PR DESCRIPTION
Users will now be able to make their rules strictly match to the domain of the URL
instead of the domain+path. 

**[Example(video)](https://streamable.com/oitji)**

Rules:

    @google.com, google
    @duckduckgo.com, ddg

`https://duckduckgo.com/?q=google.com&t=h_&ia=web` would match google sometimes because
 it included google and regex would match.

There have been other spontaneous examples with non-prefixed globs.

--------------------
Closes #44