### PR TITLE
Fix matchDomainOnly without host prefix

### DIFF
--- a/src/Storage/HostStorage.js
+++ b/src/Storage/HostStorage.js
@@ -16,7 +16,7 @@ class HostStorage extends PrefixStorage {
         try{
           return matchesSavedMap( url, matchDomainOnly, map);
         } catch (e) {
-          console.error('Error matching maps', sorted, url, matchDomainOnly, e);
+          console.error('Error matching maps', map, url, matchDomainOnly, e);
           return false;
         }
       }) || {};

--- a/src/Storage/HostStorage.js
+++ b/src/Storage/HostStorage.js
@@ -12,7 +12,14 @@ class HostStorage extends PrefixStorage {
     return super.getAll().then(maps => {
       const sorted = sortMaps(Object.keys(maps).map(key => maps[key]));
       // Sorts by domain length, then by path length
-      return sorted.find(matchesSavedMap.bind(null, url, matchDomainOnly)) || {};
+      return sorted.find((map) => {
+        try{
+          return matchesSavedMap( url, matchDomainOnly, map);
+        } catch (e) {
+          console.error('Error matching maps', sorted, url, matchDomainOnly, e);
+          return false;
+        }
+      }) || {};
     });
   }
 

--- a/src/__tests__/utils.spec.js
+++ b/src/__tests__/utils.spec.js
@@ -76,37 +76,46 @@ describe('utils', () => {
             ).toBe(true);
           });
         });
-        describe('with regex host prefix', () => {
-          it('should match url without path', () => {
-            expect(
-                utils.matchesSavedMap(
-                    'https://duckduckgo.com',
-                    matchDomainOnly, {
-                      host: '@duckduckgo.com',
-                    })
-            ).toBe(true);
-          });
-          it('should match url with path', () => {
-            expect(
-                utils.matchesSavedMap(
-                    'https://duckduckgo.com/?q=search+me+baby',
-                    matchDomainOnly, {
-                      host: '@duckduckgo.com',
-                    })
-            ).toBe(true);
-          });
-          let prefix = matchDomainOnly ? 'should not' : 'should';
-          let description = `${prefix} match url with pattern only in path`;
-          it(description, () => {
-            expect(
-                utils.matchesSavedMap(
-                    'https://google.com/?q=duckduckgo',
-                    matchDomainOnly, {
-                      host: '@duckduckgo.com',
-                    })
-            ).toBe(!matchDomainOnly);
-          });
-        });
+
+        function testPrefixes(isRegex) {
+          isRegex = !!isRegex;
+          const simplePattern = isRegex?
+              '@duckduckgo\\.com' : '!duckduckgo.com';
+          return () => {
+            it('should match url without path', () => {
+              expect(
+                  utils.matchesSavedMap(
+                      'https://duckduckgo.com',
+                      matchDomainOnly, {
+                        host: simplePattern,
+                      })
+              ).toBe(true);
+            });
+            it('should match url with path', () => {
+              expect(
+                  utils.matchesSavedMap(
+                      'https://duckduckgo.com/?q=search+me+baby',
+                      matchDomainOnly, {
+                        host: simplePattern,
+                      })
+              ).toBe(true);
+            });
+            let prefix = matchDomainOnly ? 'should not' : 'should';
+            let description = `${prefix} match url with pattern only in path`;
+            it(description, () => {
+              expect(
+                  utils.matchesSavedMap(
+                      'https://google.com/?q=duckduckgo',
+                      matchDomainOnly, {
+                        host: simplePattern,
+                      })
+              ).toBe(!matchDomainOnly);
+            });
+          };
+        }
+
+        describe('with regex host prefix', testPrefixes(true));
+        describe('with glob host prefix', testPrefixes());
       };
     }
 

--- a/src/__tests__/utils.spec.js
+++ b/src/__tests__/utils.spec.js
@@ -65,6 +65,7 @@ describe('utils', () => {
 
   describe('matchesSavedMap', () => {
     function test(matchDomainOnly) {
+      matchDomainOnly = !!matchDomainOnly;
       return () => {
         describe('without host prefix', () => {
           it('should match url without path', () => {
@@ -93,6 +94,17 @@ describe('utils', () => {
                       host: '@duckduckgo.com',
                     })
             ).toBe(true);
+          });
+          let prefix = matchDomainOnly ? 'should not' : 'should';
+          let description = `${prefix} match url with pattern only in path`;
+          it(description, () => {
+            expect(
+                utils.matchesSavedMap(
+                    'https://google.com/?q=duckduckgo',
+                    matchDomainOnly, {
+                      host: '@duckduckgo.com',
+                    })
+            ).toBe(!matchDomainOnly);
           });
         });
       };

--- a/src/__tests__/utils.spec.js
+++ b/src/__tests__/utils.spec.js
@@ -64,28 +64,23 @@ describe('utils', () => {
   });
 
   describe('matchesSavedMap', () => {
-    describe('matchDomainOnly', () => {
-      describe('without host prefix', () => {
-        const url = 'https://duckduckgo.com';
-        const host = 'duckduckgo.com';
-        const matchDomainOnly = true;
-        it('should match url without path', () => {
-          expect(
-              utils.matchesSavedMap(url, matchDomainOnly, {host})
-          ).toBeTruthy();
+    function test(matchDomainOnly) {
+      return () => {
+        describe('without host prefix', () => {
+          it('should match url without path', () => {
+            expect(
+                utils.matchesSavedMap('https://duckduckgo.com', matchDomainOnly, {
+                  host: 'duckduckgo.com',
+                })
+            ).toBe(true);
+          });
         });
-      });
-    });
-    describe('without host prefix', () => {
-      it('should match url without path', () => {
-        const url = 'https://duckduckgo.com';
-        const host = 'duckduckgo.com';
-        const matchDomainOnly = false;
-        expect(
-            utils.matchesSavedMap(url, matchDomainOnly, {host})
-        ).toBeTruthy();
-      });
-    });
+      };
+    }
+
+    test();
+    describe('matchDomainOnly', test(true));
+
   });
 
 });

--- a/src/__tests__/utils.spec.js
+++ b/src/__tests__/utils.spec.js
@@ -63,4 +63,29 @@ describe('utils', () => {
 
   });
 
+  describe('matchesSavedMap', () => {
+    describe('matchDomainOnly', () => {
+      describe('without host prefix', () => {
+        const url = 'https://duckduckgo.com';
+        const host = 'duckduckgo.com';
+        const matchDomainOnly = true;
+        it('should match url without path', () => {
+          expect(
+              utils.matchesSavedMap(url, matchDomainOnly, {host})
+          ).toBeTruthy();
+        });
+      });
+    });
+    describe('without host prefix', () => {
+      it('should match url without path', () => {
+        const url = 'https://duckduckgo.com';
+        const host = 'duckduckgo.com';
+        const matchDomainOnly = false;
+        expect(
+            utils.matchesSavedMap(url, matchDomainOnly, {host})
+        ).toBeTruthy();
+      });
+    });
+  });
+
 });

--- a/src/__tests__/utils.spec.js
+++ b/src/__tests__/utils.spec.js
@@ -75,11 +75,22 @@ describe('utils', () => {
             ).toBe(true);
           });
         });
+        describe('with regex host prefix', () => {
+          it('should match url without path', () => {
+            expect(
+                utils.matchesSavedMap(
+                    'https://duckduckgo.com/?q=search+me+baby',
+                    matchDomainOnly, {
+                      host: '@duckduckgo.com',
+                    })
+            ).toBe(true);
+          });
+        });
       };
     }
 
     test();
-    describe('matchDomainOnly', test(true));
+    describe('with matchDomainOnly', test(true));
 
   });
 

--- a/src/__tests__/utils.spec.js
+++ b/src/__tests__/utils.spec.js
@@ -79,6 +79,15 @@ describe('utils', () => {
           it('should match url without path', () => {
             expect(
                 utils.matchesSavedMap(
+                    'https://duckduckgo.com',
+                    matchDomainOnly, {
+                      host: '@duckduckgo.com',
+                    })
+            ).toBe(true);
+          });
+          it('should match url with path', () => {
+            expect(
+                utils.matchesSavedMap(
                     'https://duckduckgo.com/?q=search+me+baby',
                     matchDomainOnly, {
                       host: '@duckduckgo.com',

--- a/src/utils.js
+++ b/src/utils.js
@@ -52,9 +52,13 @@ export const pathMatch = (url, map) => {
   return true;
 };
 
+/**
+ *
+ * @param url {URL}
+ * @return {string}
+ */
 export const urlKeyFromUrl = (url) => {
-  const parsedUrl = new window.URL(url);
-  return punycode.toUnicode(parsedUrl.hostname.replace('www.', '')) + parsedUrl.pathname;
+  return punycode.toUnicode(url.hostname.replace('www.', '')) + url.pathname;
 };
 
 /**
@@ -72,8 +76,10 @@ export const urlKeyFromUrl = (url) => {
  */
 export const matchesSavedMap = (url, matchDomainOnly, {host}) => {
   let toMatch = url;
+  let urlO = new window.URL(url);
   if (matchDomainOnly) {
-    toMatch = new window.URL(url).host;
+    toMatch = urlO.host;
+    urlO = new window.URL(`${urlO.protocol}//${urlO.host}`);
   }
 
   if (host[0] === PREFIX_REGEX) {
@@ -92,7 +98,7 @@ export const matchesSavedMap = (url, matchDomainOnly, {host}) => {
         .replace(/\?/g, '.?'))
         .test(toMatch);
   } else {
-    const key = urlKeyFromUrl(toMatch);
+    const key = urlKeyFromUrl(urlO);
     const _url = ((key.indexOf('/') === -1) ? key.concat('/') : key).toLowerCase();
     const mapHost = ((host.indexOf('/') === -1) ? host.concat('/') : host).toLowerCase();
     return domainMatch(_url, mapHost) && pathMatch(_url, mapHost);

--- a/src/utils.js
+++ b/src/utils.js
@@ -70,32 +70,31 @@ export const urlKeyFromUrl = (url) => {
  * @param map
  * @return {*}
  */
-export const matchesSavedMap = (url, matchDomainOnly, map) => {
-  const savedHost = map.host;
+export const matchesSavedMap = (url, matchDomainOnly, {host}) => {
   let toMatch = url;
   if (matchDomainOnly) {
     toMatch = new window.URL(url).host;
   }
 
-  if (savedHost[0] === PREFIX_REGEX) {
-    const regex = savedHost.substr(1);
+  if (host[0] === PREFIX_REGEX) {
+    const regex = host.substr(1);
     try {
       return new RegExp(regex).test(toMatch);
     } catch (e) {
       console.error('couldn\'t test regex', regex, e);
     }
-  } else if (savedHost[0] === PREFIX_GLOB) {
+  } else if (host[0] === PREFIX_GLOB) {
     // turning glob into regex isn't the worst thing:
     // 1. * becomes .*
     // 2. ? becomes .?
-    return new RegExp(savedHost.substr(1)
+    return new RegExp(host.substr(1)
         .replace(/\*/g, '.*')
         .replace(/\?/g, '.?'))
         .test(toMatch);
   } else {
     const key = urlKeyFromUrl(toMatch);
     const _url = ((key.indexOf('/') === -1) ? key.concat('/') : key).toLowerCase();
-    const mapHost = ((map.host.indexOf('/') === -1) ? map.host.concat('/') : map.host).toLowerCase();
+    const mapHost = ((host.indexOf('/') === -1) ? host.concat('/') : host).toLowerCase();
     return domainMatch(_url, mapHost) && pathMatch(_url, mapHost);
 
   }


### PR DESCRIPTION
Using the preference "Match domain only" works well with globs and regexes, but broke matching completely when there was a pattern without a prefix. This PR remedies that, adds unit tests to prevent regressions (hopefully) and adds an error log when `matchesSavedMap` throws an exception.