### PR TITLE
Generate better {domain} container names for IP address URLs

### DIFF
--- a/src/ExtendedURL/__tests__/ExtendURL.spec.js
+++ b/src/ExtendedURL/__tests__/ExtendURL.spec.js
@@ -8,5 +8,11 @@ describe('utils', () => {
     expect(eUrl.tld).toEqual('com');
   });
 
+  it('should resolve IP to IP domain', function () {
+    const eUrl = new ExtendedURL('https://192.168.7.1');
+    expect(eUrl.domain).toEqual('192.168.7.1');
+    expect(eUrl.tld).toEqual('192.168.7.1');
+  });
+
 
 });

--- a/src/ExtendedURL/__tests__/ExtendURL.spec.js
+++ b/src/ExtendedURL/__tests__/ExtendURL.spec.js
@@ -8,11 +8,16 @@ describe('utils', () => {
     expect(eUrl.tld).toEqual('com');
   });
 
-  it('should resolve IP to IP domain', function () {
+  it('should resolve IPv4 to IPv4 address', function () {
     const eUrl = new ExtendedURL('https://192.168.7.1');
     expect(eUrl.domain).toEqual('192.168.7.1');
     expect(eUrl.tld).toEqual('192.168.7.1');
   });
 
+  it('should resolve IPv6 to IPv6 address', function () {
+    const eUrl = new ExtendedURL('https://[2001:db8::8a2e:370:7334]');
+    expect(eUrl.domain).toEqual('[2001:db8::8a2e:370:7334]');
+    expect(eUrl.tld).toEqual('[2001:db8::8a2e:370:7334]');
+  });
 
 });

--- a/src/ExtendedURL/index.js
+++ b/src/ExtendedURL/index.js
@@ -1,12 +1,22 @@
+import {looksLikeIPv4} from '../utils';
+
 export default class ExtendedURL extends URL {
   constructor(url) {
     super(url);
-    const split = this.hostname.split('.');
-    this.tld = split[split.length - 1];
-    if (split.length > 1) {
-      this.domain = split[split.length - 2];
+    this._calcDomainAndTLD();
+  }
+
+  _calcDomainAndTLD() {
+    if (looksLikeIPv4(this.hostname)) {
+      this.tld = this.domain = this.hostname;
     } else {
-      this.domain = this.tld;
+      const split = this.hostname.split('.');
+      this.tld = split[split.length - 1];
+      if (split.length > 1) {
+        this.domain = split[split.length - 2];
+      } else {
+        this.domain = this.tld;
+      }
     }
   }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -130,3 +130,18 @@ export function formatString(string, context) {
     return replacement;
   });
 }
+
+const IPV4_REGEX = /\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/;
+
+/**
+ * Naive test if a string looks like an IPv4.
+ *
+ * Should be called after firefox has done the validity check for IPv4.
+ * We can then be sure that it's an IPv4 or not.
+ *
+ * @param string {String}
+ * @return {Boolean}
+ */
+export function looksLikeIPv4(string) {
+  return !!string.match(IPV4_REGEX);
+}


### PR DESCRIPTION
When using `{domain}` as the name of default containers,
 before `192.168.178.1` would generate a container called "178".
With this PR it now generates "192.168.178.1".

Resolves #119 