### PR TITLE
Introduce truly case-sensitive matching

### DIFF
--- a/src/Storage/HostStorage.js
+++ b/src/Storage/HostStorage.js
@@ -8,11 +8,11 @@ class HostStorage extends PrefixStorage {
     this.SET_KEY = 'host';
   }
 
-  get(url, matchDomainOnly) {
+  get(url, preferences={}) {
     return super.getAll().then(maps => {
       const sorted = sortMaps(Object.keys(maps).map(key => maps[key]));
       // Sorts by domain length, then by path length
-      return sorted.find(matchesSavedMap.bind(null, url, matchDomainOnly)) || {};
+      return sorted.find(matchesSavedMap.bind(null, url, preferences)) || {};
     });
   }
 

--- a/src/containers.js
+++ b/src/containers.js
@@ -59,7 +59,7 @@ async function handle(url, tabId) {
   }
   let preferences = await PreferenceStorage.getAll(true);
   let [hostMap, identities, currentTab] = await Promise.all([
-    Storage.get(url, preferences.matchDomainOnly),
+    Storage.get(url, preferences),
     ContextualIdentity.getAll(),
     Tabs.get(tabId),
   ]);

--- a/src/ui-preferences/preferences.json
+++ b/src/ui-preferences/preferences.json
@@ -1,6 +1,12 @@
 [
   {
     "type": "bool",
+    "name": "caseSensitiveMatch",
+    "label": "Case sensitive matching",
+    "description": "The upper and lower case will be important when matching rules"
+  },
+  {
+    "type": "bool",
     "name": "matchDomainOnly",
     "label": "Match domain only",
     "description": "When matching rules to a URL, only use the domain as criteria"

--- a/src/ui/CSVEditor.js
+++ b/src/ui/CSVEditor.js
@@ -4,6 +4,7 @@ import Storage from '../Storage/HostStorage';
 import {cleanHostInput, qs} from '../utils';
 import {hideLoader, showLoader} from './loader';
 import {hideToast, showToast} from './toast';
+import PreferenceStorage from '../Storage/PreferenceStorage';
 
 const HOST_MAPS_SPLIT_KEY = ',';
 const csvEditor = qs('.csv-editor');
@@ -69,14 +70,22 @@ class CSVEditor {
     const maps = {};
     const missingContainers = new Map();
 
+    const caseSensitiveMatch = PreferenceStorage.get('caseSensitiveMatch', true);
+
     await Promise.all(items.map((item) => {
       const hostMapParts = item.split(HOST_MAPS_SPLIT_KEY);
-      const host = cleanHostInput(hostMapParts.slice(0, -1).join(HOST_MAPS_SPLIT_KEY));
+      const host = cleanHostInput(
+        hostMapParts.slice(0, -1).join(HOST_MAPS_SPLIT_KEY),
+        caseSensitiveMatch
+      );
       const containerName = hostMapParts[hostMapParts.length - 1];
       let identity;
 
       if (host && containerName) {
-        identity = this.state.identities.find((identity) => cleanHostInput(identity.name) === cleanHostInput(containerName));
+        identity = this.state.identities.find((identity) => {
+          return cleanHostInput(identity.name, caseSensitiveMatch)
+              === cleanHostInput(containerName, caseSensitiveMatch);
+        });
         if (!identity) {
           const trimmedContainer = containerName.trim();
           if (!missingContainers.has(trimmedContainer)) {

--- a/src/ui/URLMaps.js
+++ b/src/ui/URLMaps.js
@@ -1,5 +1,6 @@
 import State from '../State';
 import HostStorage from '../Storage/HostStorage';
+import PreferenceStorage from '../Storage/PreferenceStorage';
 import Tabs from '../Tabs';
 import {qs, qsAll} from '../utils';
 import {showLoader, hideLoader} from './loader';
@@ -73,14 +74,16 @@ class URLMaps {
     HostStorage.remove(host);
   }
 
-  saveUrlMaps() {
+  async saveUrlMaps() {
     showLoader();
     const items = qsAll('.url-map-item');
     const maps = {};
 
+    const caseSensitiveMatch = PreferenceStorage.get('caseSensitiveMatch', true);
+
     for (const item of items) {
       const urlInput = qs('.url-input', item);
-      const host = cleanHostInput(urlInput && urlInput.value);
+      const host = cleanHostInput(urlInput && urlInput.value, caseSensitiveMatch);
 
       if (host) {
         maps[host] = {
@@ -92,13 +95,10 @@ class URLMaps {
       }
     }
 
-    Promise.all([
-      HostStorage.setAll(maps),
-    ]).then(() => {
-      hideLoader();
-      showToast('Saved!');
-      setTimeout(() => hideToast(), 3000);
-    });
+    await HostStorage.setAll(maps);
+    hideLoader();
+    showToast('Saved!');
+    setTimeout(() => hideToast(), 3000);
   }
 
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -7,7 +7,18 @@ export const qs = (selector, node) => (node || document).querySelector(selector)
 export const qsAll = (selector, node) => (node || document).querySelectorAll(selector);
 export const ce = (tagName) => document.createElement(tagName);
 
-export const cleanHostInput = (value = '') => value.trim().toLowerCase();
+/**
+ * Makes sure the host coming from user input can be used elsewhere
+ *
+ * @param host {String}
+ * @param caseSensitive {Boolean} Whether the host is case sensitive.
+ *                      Insensitive means it should be lowercased
+ * @return {String}
+ */
+export function cleanHostInput(host = '', caseSensitive=true){
+  host = host.trim();
+  return caseSensitive ? host : host.tolowerCase();
+}
 
 const getDomain = (src = '') => src.split('/')[0];
 const getPath = (src = '') => src.replace(/^.+?\//, '');

--- a/src/utils.js
+++ b/src/utils.js
@@ -77,13 +77,18 @@ export const urlKeyFromUrl = (url) => {
  *  - standard
  *
  * @param url {String}
- * @param matchDomainOnly {Boolean=}
+ * @param preferences {Object}
  * @param map
  * @return {*}
  */
-export const matchesSavedMap = (url, matchDomainOnly, map) => {
-  const savedHost = map.host;
+export const matchesSavedMap = (url, preferences, map) => {
+  let savedHost = map.host;
   let toMatch = url;
+  const{matchDomainOnly, caseSensitiveMatch} = preferences;
+  if(!caseSensitiveMatch){
+    savedHost = savedHost.toLowerCase();
+    toMatch = toMatch.toLowerCase();
+  }
   if (matchDomainOnly) {
     toMatch = new window.URL(url).host;
   }


### PR DESCRIPTION
User input used to be lowercased. That led to #120 where URLs with uppercase letters couldn't be matched by regexes.

This PR introduces the `caseSensitiveMatch` option and aligns the input and URL to match.

caseSensitiveMatch = true --> user input isn't lowercased

caseSensitiveMatch = false --> user input **and** url is lowercased

#Resolves #120