### PR TITLE
Keep more properties when re-opening tabs

### DIFF
--- a/src/containers.js
+++ b/src/containers.js
@@ -20,6 +20,9 @@ const createTab = (url, newTabIndex, currentTabId, openerTabId, cookieStoreId) =
       index: newTabIndex,
       cookieStoreId,
       active: currentTab.active,
+      pinned: currentTab.pinned,
+      discarded: currentTab.discarded,
+      openInReaderMode: currentTab.isInReaderMode,
     };
     // Passing the openerTabId without a cookieStoreId
     // creates a tab in the same container as the opener


### PR DESCRIPTION
Properties like "pinned", "discarded", and "isInReaderMode" cannot
be set for tabs freshly opened by user, but they can be set for tabs
opened by other extensions.

Fixes #132.