### PR TITLE
fix issue where www.* hostnames don't work

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -58,7 +58,7 @@ export const pathMatch = (url, map) => {
  * @return {string}
  */
 export const urlKeyFromUrl = (url) => {
-  return punycode.toUnicode(url.hostname.replace('www.', '')) + url.pathname;
+  return punycode.toUnicode(url.hostname) + url.pathname;
 };
 
 /**


### PR DESCRIPTION
Fixes https://github.com/kintesh/containerise/issues/138

I'm not 100% sure this doesn't break other functionality though as I don't really understand why this `replace()` was there in the first place, and it seems to have been there from the beginning https://github.com/kintesh/containerise/blob/1eabe7b16bf3e1b411be349a1241257c19181fa1/src/webRequestListener.js#L12

If @kintesh has some insight into the reason for the `replace()`, that might help.
