### PR TITLE
Remove temporary tabs if keepOldTabs is true. Fixes #93

### DIFF
--- a/src/containers.js
+++ b/src/containers.js
@@ -38,7 +38,14 @@ const createTab = (url, newTabIndex, currentTabId, openerTabId, cookieStoreId) =
       }
     });
     PreferenceStorage.get('keepOldTabs').then(({value}) => {
-      if (!value) {
+      // if keepOldTabs is false, remove the 'old' tab
+      // -or-
+      // if the current tab is about:blank or about:newtab
+      // or some custom moz-extension pages
+      // we should still close the current tab even though
+      // keepOldTabs is true, because these are just
+      // interstitial tabs that are no longer used
+      if (!value || /^(about:)|(moz-extension:)/.test(currentTab.url)) {
         Tabs.remove(currentTabId);
       }
     }).catch(() => {


### PR DESCRIPTION
This fixes #93 .

It'll remove about:blank or about:newtab tabs temporary tabs when switching containers.

I can't promise it's a perfect solution as I'm not intimately familiar with the codebase, however, I tested it locally and it seemed to accomplish the task.

Let me know if you need me to make any changes, but I think this improves the `keepOldTabs` UX quite a bit. Thanks!

Addt'l info: I've been using this for a few hours and it's a huge improvement, haven't noticed any bugs yet. I'll follow up if I find any bugs.