### PR TITLE
Enable sites to "open in current container" via setting

### DIFF
--- a/src/containers.js
+++ b/src/containers.js
@@ -68,6 +68,12 @@ async function handle(url, tabId) {
     delete creatingTabs[tabId];
   }
   let preferences = await PreferenceStorage.getAll(true);
+  const OPEN_IN_CURRENT_CONTAINER = '(' + preferences.openInCurrentContainer + ')/';
+  let OPEN_IN_CURRENT_CONTAINER_REGEX = new RegExp(OPEN_IN_CURRENT_CONTAINER);
+  if (OPEN_IN_CURRENT_CONTAINER_REGEX.test(url)) {
+    //console.debug('URL was left in current container due to Regex--> ', url);
+    return;
+  }
   let [hostMap, identities, currentTab] = await Promise.all([
     Storage.get(url, preferences.matchDomainOnly),
     ContextualIdentity.getAll(),

--- a/src/ui-preferences/preferences.json
+++ b/src/ui-preferences/preferences.json
@@ -11,6 +11,13 @@
     "label": "Keep old tabs",
     "description": "After a contained tab has been created, the old won't be closed"
   },
+  { 
+    "type": "string",
+    "name": "openInCurrentContainer",
+    "label": "Open in current container",
+    "description": "A list of domains separated by a pipe (|) which will *always* open in the current container that opened them",
+    "defaultValue": ""
+  },
   {
     "type": "group",
     "name": "defaultContainer",


### PR DESCRIPTION
This enhancement enables you to specify which sites should always open in the container that they were launched from - regardless of other rules.  This enables you to open the same site in multiple containers based on your starting point.  It also enables sites that must remain in the same container as the original site (such as paypal.com) to remain in the container they were launched from to ensure that the transaction flow works smoothly.

This enhancement addresses feature requests #165, #148, #24 (and possibly others)