### PR TITLE
Add support for Temporary Containers Plus extension

### DIFF
--- a/src/messageExternalListener.js
+++ b/src/messageExternalListener.js
@@ -2,6 +2,7 @@ import HostStorage from './Storage/HostStorage';
 
 const allowedExternalExtensions = [
   '{c607c8df-14a7-4f28-894f-29e8722976af}', // Temporary Containers
+  '{1ea2fa75-677e-4702-b06a-50fc7d06fe7e}', // Temporary Containers Plus
 ];
 
 export const messageExternalListener = (message, sender) => {


### PR DESCRIPTION
This change adds the extension ID for Temporary Containers Plus ({1ea2fa75-677e-4702-b06a-50fc7d06fe7e}) to the allowedExternalExtensions list, enabling compatibility with the active version of Temporary Containers as requested by users [here](https://github.com/GodKratos/temporary-containers/issues/38).

The extension uses the same message API (getHostMap method) as the original Temporary Containers extension, so no other changes are needed.

The original Temporary Containers addon is no longer maintained as the original developer has passed away. Temporary Containers Plus is now the active replacement.